### PR TITLE
Redis traffic shaping

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,16 @@
 CHANGES
 =======
 
+* closed #8
+* nothing to see
+* fix test for membership
+* fix test
+* fix the fix
+* fix import
+* rm unused import
+* fix test
+* fix pep8
+* docs
 * fix blacklisting and suspending requests; extend wsgi configuration for max\_sleep\_time\_seconds, log\_sleep\_time\_seconds
 * fix retry-after header value
 * align metric labels with watcher middleware; verify backend on start; update examples in docs

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ The [openstack-watcher-middleware](https://github.com/sapcc/openstack-watcher-mi
 based on the [DMTF CADF specification](https://www.dmtf.org/standards/cadf).
 In terms of rate limiting, a request to an OpenStack service can be described by an *action*, *target type URI* and its *scope*.
 
-Moreover, this middleware uses a backend to store rate limits.  
-Thus either `Redis >= 5.0.0` (stable; preferred) or `Memcached >= 1.5.12` (beta) is required as a datastore.
+Moreover, this middleware uses `Redis >= 5.0.0` as a backend to store rate limits. 
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ The OpenStack Rate Limit Middleware enforces rate limits and enables traffic sha
 It also supports enforcing global and scoped rate limits.
 More details can be found in the documentation.
 
-## Prerequisite
+## Prerequisites
 
 This middleware requires the classification for OpenStack requests.  
 The [openstack-watcher-middleware](https://github.com/sapcc/openstack-watcher-middleware) can be used to classify requests
 based on the [DMTF CADF specification](https://www.dmtf.org/standards/cadf).
 In terms of rate limiting, a request to an OpenStack service can be described by an *action*, *target type URI* and its *scope*.
 
-Moreover, this middleware uses `Redis >= 5.0.0` as a backend to store rate limits. 
+Moreover, this middleware uses `Redis >= 5.0.0` as a backend to store rate limits.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ OpenStack Rate Limit Middleware
 
 [![Build Status](https://travis-ci.org/sapcc/openstack-rate-limit-middleware.svg?branch=master)](https://travis-ci.org/sapcc/openstack-rate-limit-middleware)
 
-The OpenStack Rate Limit Middleware enables traffic control for OpenStack APIs per tuple of
+The OpenStack Rate Limit Middleware enforces rate limits and enables traffic shaping for OpenStack APIs per tuple of
 - *target type URI*
 - *action*
 - *scope* (project, host address)

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -3,7 +3,7 @@ Middleware configuration
 
 This sections provides an overview of the configurable options via WSGI config and configuration file.
 
-## Global and local rate limits
+# Global and local rate limits
 
 Rate limits can be enforced on 2 levels: Global and local.
   
@@ -17,7 +17,7 @@ Rate limits can be enforced on 2 levels: Global and local.
   If the number of requests per scope, action, target type URI within the specified window would exceed the configured maximum,
     a configurable rate limit response is sent until the number of requests within the window is again below the maximum.
 
-## Configure rate limits
+# Configure rate limits
 
 Rate limits can be configured via a *configuration file* and/or via [*Limes*](https://github.com/sapcc/limes). 
 The configuration file can only be used to specify global rate limits and defaults for local rate limits.
@@ -35,61 +35,6 @@ rates:
               # Limit to n requests per m <unit>. 
               # Valid interval units are `s, m, h, d`.
               limit:    <n>r/<m><t>
-```
-
-
-## Black- & Whitelist
-
-This middleware allows configuring a black- and whitelist for certain scopes.
-A scope might be an (initiator/target) project UUID or an initiator host address.   
-If a scope is blacklisted, the middleware immediately returns the configured blacklist response. 
-Requests in a whitelisted scope are not rate limited.  
-Also see the [examples](../etc/).  
-
-```yaml
-# List of blacklisted scopes (project UUID, host address).
-blacklist:
-    - <scope>
-
-# List of whitelisted scoped (project UUID, host address).
-whitelist:
-    - <scope>
-```
-
-## Customize responses
-
-The blacklist and rate limit responses can be configured as shown below.  
-A custom response requires the **status**, **status_code** and **body** or **json_body** to be specified.
-```yaml
-rate_limit_response:
-  # HTTP response status string.
-  status: 498 Rate Limited
-  
-  # HTTP response status code.
-  status_code: 498
-  
-  # Specify *either* body or json_body.
-  body:  "<html><body><h1>Rate limit exceeded</h1></body></html>"
-  # json_body: { "message": "rate limit exceeded" }
-  
-  # Optional: Set additional headers.
-  headers:
-    X-SERVICE: SOMETHING
-
-blacklist_response:
-  # HTTP response status string.
-  status: 497 Blacklisted
-  
-  # HTTP response status code.
-  status_code: 497
-  
-  # Specify *either* body or json_body.
-  body:  "<html><body><h1>You have been blacklisted. Contact an administrator.</h1></body></html>"
-  # json_body: { "message": "You have been blacklisted. Please contact and administrator." }
-  
-  # Optional: Set additional headers.
-  headers:
-    X-SERVICE: SOMETHING
 ```
 
 ## Rate limit groups
@@ -160,7 +105,61 @@ rates:
         limit: 5r/10m
 ``` 
 
-## Testing
+## Black- & Whitelist
+
+This middleware allows configuring a black- and whitelist for certain scopes.
+A scope might be an (initiator/target) project UUID or an initiator host address.   
+If a scope is blacklisted, the middleware immediately returns the configured blacklist response. 
+Requests in a whitelisted scope are not rate limited.  
+Also see the [examples](../etc/).  
+
+```yaml
+# List of blacklisted scopes (project UUID, host address).
+blacklist:
+    - <scope>
+
+# List of whitelisted scoped (project UUID, host address).
+whitelist:
+    - <scope>
+```
+
+## Customize responses
+
+The blacklist and rate limit responses can be configured as shown below.  
+A custom response requires the **status**, **status_code** and **body** or **json_body** to be specified.
+```yaml
+rate_limit_response:
+  # HTTP response status string.
+  status: 498 Rate Limited
+  
+  # HTTP response status code.
+  status_code: 498
+  
+  # Specify *either* body or json_body.
+  body:  "<html><body><h1>Rate limit exceeded</h1></body></html>"
+  # json_body: { "message": "rate limit exceeded" }
+  
+  # Optional: Set additional headers.
+  headers:
+    X-SERVICE: SOMETHING
+
+blacklist_response:
+  # HTTP response status string.
+  status: 497 Blacklisted
+  
+  # HTTP response status code.
+  status_code: 497
+  
+  # Specify *either* body or json_body.
+  body:  "<html><body><h1>You have been blacklisted. Contact an administrator.</h1></body></html>"
+  # json_body: { "message": "You have been blacklisted. Please contact and administrator." }
+  
+  # Optional: Set additional headers.
+  headers:
+    X-SERVICE: SOMETHING
+```
+
+# Testing
 
 This middleware offers a variety of options for rate limiting and traffic shaping for an OpenStack API.  
 Whether the current configuration and behaviour matches the users expectations can be verified using [siege](https://github.com/JoeDog/siege) - a load testing and benchmarking toolkit.

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -29,9 +29,11 @@ The syntax for minimal configuration of rate limits is described below.
 rates:
     <level>:
         <target_type_uri>:
+              # The name of the action.
             - action:   <action type>
-              # limit to n requests per m <unit> 
-              # valid interval units are `s, m, h, d`.
+            
+              # Limit to n requests per m <unit>. 
+              # Valid interval units are `s, m, h, d`.
               limit:    <n>r/<m><t>
 ```
 
@@ -157,3 +159,61 @@ rates:
       - action: create 
         limit: 5r/10m
 ``` 
+
+## Testing
+
+This middleware offers a variety of options for rate limiting and traffic shaping for an OpenStack API.  
+Whether the current configuration and behaviour matches the users expectations can be verified using [siege](https://github.com/JoeDog/siege) - a load testing and benchmarking toolkit.
+Install on OSX using [homebrew](https://formulae.brew.sh/formula/siege) `brew install siege`.
+
+Assuming that a valid token was issued by OpenStack Keystone and is available as `OS_AUTH_TOKEN`:
+```bash
+# Obtain token.
+export OS_AUTH_TOKEN=$(openstack token issue -c id -f value)
+
+# Send 10 concurrent requests to an endpoint and benchmark.
+siege --concurrent=1 --reps=10 --benchmark -header="X-AUTH-TOKEN:$OS_AUTH_TOKEN" https://$OpenStackURI
+```
+
+Example: 
+
+Test OpenStack Swift `POST account/container`
+
+(1) Send 3 concurrent POST requests to update a Swift container using `siege`:
+```bash
+siege --concurrent=1 --reps=3 --benchmark --header="X-AUTH-TOKEN:$OS_AUTH_TOKEN" 'https://$OpenStackURI/v1/AUTH_$ProjectID/mycontainer POST'
+```
+
+The output for a rate of `1r/m` and `max_delay_seconds=0` (nodelay) could look as follows:
+```bash
+The server is now under siege...
+HTTP/1.1 204     0.20 secs:       0 bytes ==> POST https://$OpenStackURI/v1/AUTH_$ProjectID/mycontainer
+HTTP/1.1 498     0.09 secs:      19 bytes ==> POST https://$OpenStackURI/v1/AUTH_$ProjectID/mycontainer
+HTTP/1.1 498     0.11 secs:      19 bytes ==> POST https://$OpenStackURI/v1/AUTH_$ProjectID/mycontainer
+```
+Only the 1st request is processed and the 2 subsequent, almost concurrently issued, requests are rejected as the rate limit of `1r/m` is exceeded.
+
+(2) Send 10 requests with a a random delay of 1s to 10s between each request:
+```bash
+siege --reps=10 --delay=10 --header="X-AUTH-TOKEN:$OS_AUTH_TOKEN" 'https://$OpenStackURI/v1/AUTH_$ProjectID/mycontainer POST'
+```
+
+The output for a rate of `2r/m` and `max_delay_seconds=20` could look as follows:
+```bash
+The server is now under siege...
+HTTP/1.1 204     0.36 secs:       0 bytes ==> POST https://$OpenStackURI/v1/AUTH_$ProjectID/mycontainer
+HTTP/1.1 204     0.22 secs:       0 bytes ==> POST https://$OpenStackURI/v1/AUTH_$ProjectID/mycontainer
+HTTP/1.1 498     0.10 secs:      19 bytes ==> POST https://$OpenStackURI/v1/AUTH_$ProjectID/mycontainer
+HTTP/1.1 498     0.11 secs:      19 bytes ==> POST https://$OpenStackURI/v1/AUTH_$ProjectID/mycontainer
+HTTP/1.1 498     0.12 secs:      19 bytes ==> POST https://$OpenStackURI/v1/AUTH_$ProjectID/mycontainer
+HTTP/1.1 498     0.10 secs:      19 bytes ==> POST https://$OpenStackURI/v1/AUTH_$ProjectID/mycontainer
+HTTP/1.1 204    19.72 secs:       0 bytes ==> POST https://$OpenStackURI/v1/AUTH_$ProjectID/mycontainer
+HTTP/1.1 204     0.11 secs:       0 bytes ==> POST https://$OpenStackURI/v1/AUTH_$ProjectID/mycontainer
+...
+```
+
+The 1st and 2nd request are successfully processed within the rate limit of `2r/m`. 
+The 3rd to 6th requests are rejected as the rate limit is exceeded and the request would need to be suspended for longer than `max_delay_seconds`.
+However, the 7th request still exceeds the rate limit but reaches the API just less than 20s before it could be successfully processed according to the rate limit.
+Thus it is suspended for ~19 seconds and processed afterwards as indicated by the relatively long transaction time.
+Request #8 is successfully processed, but  

--- a/docs/draft_limes.md
+++ b/docs/draft_limes.md
@@ -1,11 +1,15 @@
 Limes integration
 =================
 
-[Limes](https://github.com/sapcc/limes) currently reports resource quota and usage for a project as described [here](https://github.com/sapcc/limes/blob/master/docs/users/api-v1-specification.md#get-v1domainsdomain_idprojectsproject_id).
-Add rate limits by extending the JSON document as follows.
+Global rate limits and defaults for each project can be defined via a [configuration file](./configure.md).  
+However, the configuration file does not allow defining rate limits specific for a project.  
+This can only be done using [Limes](https://github.com/sapcc/limes) as outlined below. 
+Limes reports rate limits for a project as described [here](https://github.com/sapcc/limes/blob/master/docs/users/api-v1-specification.md#get-v1domainsdomain_idprojectsproject_id).
+
+Note the usage of the `rate=only` query parameter to only report rate limits.
 
 Example:  
-**GET /v1/domains/:domain_id/projects/:project_id**
+**GET /v1/domains/:domain_id/projects/:project_id?rates=only**
 ```
 {
     "projects": [
@@ -15,12 +19,7 @@ Example:
             "services": [
                 {
                     "type": "object-store",
-                    "area": "storage",
-                    "resources": [
-                        {
-                        ...
-                        }
-                    ],
+                    "area": "storage"
                     "rates": [
                         {
                             "targetTypeURI": "account/container",
@@ -43,7 +42,7 @@ Example:
 }
 ```
 
-**Defaults** for each project will be deployed using limes' constraints.
+**Defaults** for each project may be deployed using limes' constraints.
 
 ```
 limes: 

--- a/docs/install.md
+++ b/docs/install.md
@@ -19,51 +19,63 @@ pipeline = .. sapcc-watcher sapcc-rate-limit ..
 The following parameters are provided via the WSGI configuration:
 ```yaml
 # The service type according to CADF specification.
-service_type:     <string>
+service_type:                   <string>
 
 # Path to the configuration file.
-config_file:      <string>
+config_file:                    <string>
 
 # If this middleware enforces rate limits in multiple replicas of an API,
 # the clock accuracy of the individual replicas can be configured as follows.
-clock_accuracy:   <n><unit> (default 1ms)
+clock_accuracy:                 <n><unit> (default: 1ms)
 
 # Per default rate limits are applied based on `initiator_project_id`.
 # However, this can also be se to `initiator_host_address` or `target_project_id`.
-rate_limit_by:    <string>
+rate_limit_by:                  <string>
 
 # The maximal time a request can be suspended in seconds.
 # Instead of immediately returning a rate limit response, a request can be suspended
 # until the specified maximum duration to fit the configured rate limit. 
 # This feature can be disabled by setting the max sleep time to 0 seconds.
-max_sleep_time_seconds: <int> (default: 20)
+max_sleep_time_seconds:         <int> (default: 20)
 
 # Log requests that are going to be suspended for log_sleep_time_seconds <= t <= max_sleep_time_seconds.
-log_sleep_time_seconds: <int> (default: 10)
+log_sleep_time_seconds:         <int> (default: 10)
 
 # Emit Prometheus metrics via StatsD.
 # Host of the StatsD exporter.
-statsd_host:      <string> (default: 127.0.0.1)
+statsd_host:                    <string> (default: 127.0.0.1)
 
 # Port of the StatsD exporter.
-statsd_port:      <int> (default: 9125)
+statsd_port:                    <int> (default: 9125)
 
 # Prefix to apply to all metrics provided by this middleware.
-statsd_prefix:    <string> (default: openstack_ratelimit_middleware)
+statsd_prefix:                  <string> (default: openstack_ratelimit_middleware)
 
 # Host for redis backend.
-backend_host:     <string> (default: 127.0.0.1)
+backend_host:                   <string> (default: 127.0.0.1)
 
 # Port for redis backend.
-backend_port:     <int> (default: 6379)
+backend_port:                   <int> (default: 6379)
 
-## Limes configuration.
-# Rate limits con be provided via Limes.
-limes_enabled:    <bool> (default: false)
+## Configure Limes as provider for rate limits.
+# See the limes guide for more details.
+limes_enabled:                  <bool> (default: false)
+
+# URI of the Limes API.
+# If not provided, the middleware attempts to autodiscover the URI of the Limes API using the  
+# service catalog of the Keystone token.
+limes_api_uri:                  <string>
+
+# To avoid querying for rate limits for each requests, rate limits obtained from Limes are cached in Redis.
+# Specify the interval in which cached rate limits are refreshed in seconds.
+# Setting 0 here disabled the caching. The middleware will query Limes for rate limits for every requests.
+# This might have a negative effect on your applications performance.
+limes_refresh_interval_seconds: <int> (default: 300)
+
 # Credentials of the OpenStack service user able to read rate limits from Limes.
-auth_url:         <string>
-username:         <string>
-user_domain_name: <string>
-password:         <string>
-domain_name:      <string>
+identity_auth_url:              <string>
+username:                       <string>
+user_domain_name:               <string>
+password:                       <string>
+domain_name:                    <string>
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -35,6 +35,7 @@ rate_limit_by:    <string>
 # The maximal time a request can be suspended in seconds.
 # Instead of immediately returning a rate limit response, a request can be suspended
 # until the specified maximum duration to fit the configured rate limit. 
+# This feature can be disabled by setting the max sleep time to 0 seconds.
 max_sleep_time_seconds: <int> (default: 20)
 
 # Log requests that are going to be suspended for log_sleep_time_seconds <= t <= max_sleep_time_seconds.

--- a/docs/install.md
+++ b/docs/install.md
@@ -51,14 +51,10 @@ statsd_port:      <int> (default: 9125)
 # Prefix to apply to all metrics provided by this middleware.
 statsd_prefix:    <string> (default: openstack_ratelimit_middleware)
 
-# The backend used to store number of requests.
-# Choose between redis, memcache.
-backend:          <string> (default: redis)
-
-# Host for backend.
+# Host for redis backend.
 backend_host:     <string> (default: 127.0.0.1)
 
-# Port for backend.
+# Port for redis backend.
 backend_port:     <int> (default: 6379)
 
 ## Limes configuration.

--- a/docs/user.md
+++ b/docs/user.md
@@ -33,6 +33,7 @@ X-RateLimit-Reset: 60
 X-Retry-After: 60
 ```
 
+
 # Metrics
 
 This middleware emits the following [Prometheus metrics](https://prometheus.io/docs/concepts/metric_types) via [StatsD](https://github.com/DataDog/datadogpy).  
@@ -53,3 +54,26 @@ All metrics come with the following labels:
 | action          | The CADF action of the request. |
 | scope           | The scope of the request. |
 | target_type_uri | The CADF target type URI of the request. |
+
+
+# Burst requests
+
+This middleware is capable of handling a burst of requests as described hereinafter.
+
+## With delay
+
+This middleware handles requests that would exceed the configured rate by delaying them until the next possible slot but not longer than `max_sleep_time_seconds`.
+See the [WSGI section](install.md) on how to configure this. 
+
+Example:  
+Given a `rate limit=1r/m` and a `max_sleep_time_seconds=20`, the 1st request at t<sub>1</sub>=0 would be processed just fine. 
+However, a 2nd request received within the one minute window after the 1st request would exceed the rate limit.
+Assuming it's received at t<sub>2</sub>=45, the request would not be rejected but suspended for 15 seconds and processed afterwards so that the rate of `1r/m` is not exceeded. 
+
+However, this behaviour might let your application appear slow for a user. 
+It can be disabled by setting `max_sleep_time_seconds=0` and using burst requests without delay as described below.
+
+## Without delay
+
+Handling burst requests without delay 
+

--- a/rate_limit/backend.py
+++ b/rate_limit/backend.py
@@ -94,7 +94,7 @@ class RedisBackend(Backend):
             )
             return
         self.__rate_limit_script = script
-        self.__rate_limit_script_sha = hashlib.sha1(script).hexdigest()
+        self.__rate_limit_script_sha = hashlib.sha1(script.encode('utf-8')).hexdigest()
 
     def is_available(self):
         """Check whether the redis is available and supported."""

--- a/rate_limit/backend.py
+++ b/rate_limit/backend.py
@@ -15,8 +15,6 @@
 import eventlet
 import hashlib
 import logging
-import math
-import memcache
 import redis
 import time
 
@@ -177,8 +175,8 @@ class RedisBackend(Backend):
             )
 
         # Parse result list safely.
-        remaining = common.list_to_int(result, idx=0)
-        retry_after_seconds = common.list_to_int(result, idx=1)
+        remaining = common.listitem_to_int(result, idx=0)
+        retry_after_seconds = common.listitem_to_int(result, idx=1)
 
         # Return here if we still have remaining requests.
         if remaining > 0:

--- a/rate_limit/common.py
+++ b/rate_limit/common.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import os
 import time
 import yaml
 
@@ -148,3 +149,42 @@ def load_config(cfg_file):
         raise errors.ConfigError("Failed to load configuration from file %s: %s" % (cfg_file, str(e)))
     finally:
         return yaml_conf
+
+
+def to_int(raw_value, default=0):
+    """
+    Safely parse a raw value and convert to an integer.
+    If that fails return the default value.
+
+    :param raw_value: the raw value
+    :param default: the fallback value if conversion fails
+    :return: the value as int or None
+    """
+    try:
+        val = int(float(raw_value))
+        return val
+    except (ValueError, TypeError):
+        return default
+
+
+def load_lua_script(filename, foldername="lua"):
+    """
+    Load a lua scripts.
+
+    :param filename: the filename of the script
+    :param foldername: the name of the folder containing the script
+    :return: the content or None
+    """
+    content = None
+    path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "{0}/{1}".format(foldername, filename)
+    )
+    try:
+        f = open(path)
+        content = f.read()
+        f.close()
+    except IOError:
+        return None
+    finally:
+        return content

--- a/rate_limit/common.py
+++ b/rate_limit/common.py
@@ -161,9 +161,23 @@ def to_int(raw_value, default=0):
     :return: the value as int or None
     """
     try:
-        val = int(float(raw_value))
-        return val
+        return int(float(raw_value))
     except (ValueError, TypeError):
+        return default
+
+
+def listitem_to_int(listthing, idx, default=0):
+    """
+    Safely get an item by index from a list.
+
+    :param listthing: the list
+    :param idx: the index of the item
+    :param default: the default value if item not found
+    :return: the item as int or the default value
+    """
+    try:
+        return to_int(listthing[idx], default)
+    except (IndexError, TypeError):
         return default
 
 

--- a/rate_limit/common.py
+++ b/rate_limit/common.py
@@ -48,7 +48,6 @@ class Constants(object):
     limes_refresh_interval_seconds = 300
 
     backend_redis = 'redis'
-    backend_memcache = 'memcache'
 
     # The limit for the current request in the format <n>r/<m><t>.
     # Read: Limit to n requests per m <unit>. Valid interval units are `s, m, h, d`.

--- a/rate_limit/common.py
+++ b/rate_limit/common.py
@@ -39,13 +39,19 @@ class Constants(object):
     log_sleep_time_seconds = 'log_sleep_time_seoncds'
     unknown = 'unknown'
 
-    # rate limit by ..
+    # Rate limit by ..
     initiator_project_id = 'initiator_project_id'
     initiator_host_address = 'initiator_host_address'
     target_project_id = 'target_project_id'
 
-    # fetch rate limits from limes every t seconds
-    limes_refresh_interval_seconds = 300
+    # Interval in which cached rate limits are refreshed in seconds.
+    limes_refresh_interval_seconds = 'limes_refresh_interval_seconds'
+
+    # The URI of the Limes API.
+    limes_api_uri = 'limes_api_uri'
+
+    # Type of the Limes service as found in token service catalog.
+    limes_service_type = 'limes'
 
     backend_redis = 'redis'
 
@@ -201,3 +207,16 @@ def load_lua_script(filename, foldername="lua"):
         return None
     finally:
         return content
+
+
+def build_uri(base, path):
+    """
+    Build the URI using base and path.
+
+    :param base:
+    :param path:
+    :return:
+    """
+    base = base.rstrip('/')
+    path = path.lstrip('/')
+    return base + '/' + path

--- a/rate_limit/common.py
+++ b/rate_limit/common.py
@@ -53,8 +53,6 @@ class Constants(object):
     # Type of the Limes service as found in token service catalog.
     limes_service_type = 'limes'
 
-    backend_redis = 'redis'
-
     # The limit for the current request in the format <n>r/<m><t>.
     # Read: Limit to n requests per m <unit>. Valid interval units are `s, m, h, d`.
     header_ratelimit_limit = 'X-RateLimit-Limit'

--- a/rate_limit/errors.py
+++ b/rate_limit/errors.py
@@ -19,18 +19,6 @@ class ConfigError(Exception):
     pass
 
 
-class MemcacheConnectionError(Exception):
-    """Raised when connection to memcached caused an error."""
-
-    pass
-
-
-class MaxSleepTimeHitError(Exception):
-    """Raised when the maximal sleep time was hit for a key."""
-
-    pass
-
-
 class UnitConversionError(Exception):
     """Raised when a unit is invalid and cannot be converted."""
 

--- a/rate_limit/lua/redis_sliding_window.lua
+++ b/rate_limit/lua/redis_sliding_window.lua
@@ -1,0 +1,26 @@
+local key, lookback_timestamp_max_int, now_int, max_calls_int, window_seconds_int
+key = tostring(KEYS[1])
+lookback_timestamp_max_int = tonumber(KEYS[2])
+now_int = tonumber(KEYS[3])
+max_calls_int = tonumber(KEYS[4])
+window_seconds_int = tonumber(KEYS[5])
+-- Rate limit algorithm inspired by https://engineering.classdojo.com/blog/2015/02/06/rolling-rate-limiter
+-- While this works well for rate limiting we need a slightly more advanced lua script for shaping the traffic,
+-- like allowing burst requests with delayed/not delayed execution.
+-- Remove all API calls that are older than the sliding window.
+redis.call('zremrangebyscore', key, '-inf', lookback_timestamp_max_int)
+-- List of API calls during sliding window.
+local reqs = redis.call('zrange', key, 0, -1)
+local count = 0
+for _ in pairs(reqs) do count = count + 1 end
+-- Get number of remaining requests.
+local remaining = max_calls_int - count
+-- Add timestamp of current request if there are remaining requests.
+if remaining > 0 then
+    -- Add timestamp if we still have remaining requests.
+    redis.call('zadd', key, now_int, now_int)
+    -- Reset expiry time for key.
+    redis.call('expire', key, window_seconds_int)
+end
+-- Returns the number of remaining requests and the list of timestamps.
+return remaining, reqs

--- a/rate_limit/provider.py
+++ b/rate_limit/provider.py
@@ -22,7 +22,6 @@ from keystoneauth1.identity import v3
 from keystoneauth1 import session
 
 from . import common
-from . import errors
 
 logging.basicConfig(level=logging.ERROR, format='%(asctime)-15s %(message)s')
 

--- a/rate_limit/provider.py
+++ b/rate_limit/provider.py
@@ -40,7 +40,7 @@ class RateLimitProvider(object):
         Get the global rate limit per action and target type URI.
         Returns -1 if unlimited.
 
-        :param action: the cadf action for the request
+        :param action: the CADF action for the request
         :param target_type_uri: the target type URI of the request
         :param kwargs: optional, additional parameters
         :return: the global rate limit or -1 if not set
@@ -52,7 +52,7 @@ class RateLimitProvider(object):
         Get the local (project/domain/ip, ..) rate limit per scope, action, target type URI.
 
         :param scope: the UUID of the project, domain or the IP
-        :param action: the cadf action of the request
+        :param action: the CADF action of the request
         :param target_type_uri: the target type URI of the request
         :param kwargs: optional, additional parameters
         :return: the local rate limit or -1 if not set
@@ -73,7 +73,7 @@ class ConfigurationRateLimitProvider(RateLimitProvider):
         Get the global rate limit per action and target type URI.
         Returns -1 if unlimited.
 
-        :param action: the cadf action for the request
+        :param action: the CADF action for the request
         :param target_type_uri: the target type URI of the request
         :param kwargs: optional, additional parameters
         :return: the global rate limit or -1 (unlimited) if not set
@@ -90,7 +90,7 @@ class ConfigurationRateLimitProvider(RateLimitProvider):
         Get the local (project/domain/ip, ..) rate limit per scope, action, target type URI.
 
         :param scope: the UUID of the project, domain or the IP
-        :param action: the cadf action of the request
+        :param action: the CADF action of the request
         :param target_type_uri: the target type URI of the request
         :param kwargs: optional, additional parameters
         :return: the local rate limit or -1 if not set

--- a/rate_limit/rate_limit.py
+++ b/rate_limit/rate_limit.py
@@ -45,7 +45,7 @@ class OpenStackRateLimitMiddleware(object):
 
         # StatsD is used to emit metrics.
         statsd_host = wsgi_config.get('statsd_host', '127.0.0.1')
-        statsd_port = wsgi_config.get('statsd_port', 9125)
+        statsd_port = common.to_int(wsgi_config.get('statsd_port', 9125))
         statsd_prefix = wsgi_config.get('statsd_prefix', 'openstack_ratelimit')
 
         # Init StatsD client.
@@ -58,13 +58,12 @@ class OpenStackRateLimitMiddleware(object):
         # Get backend configuration.
         # Backend is used to store count of requests.
         backend_type = wsgi_config.get('backend', 'redis')
-        self.logger.debug('using backend: {0}'.format(backend_type))
-
         backend_host = wsgi_config.get('backend_host', '127.0.0.1')
-        self.logger.debug('using backend host {0}'.format(backend_host))
+        backend_port = common.to_int(self.wsgi_config.get('backend_port'), 6379)
+        self.logger.debug("using backend '{0}' on '{1}:{2}'".format(backend_type, backend_host, backend_port))
 
-        backend_port = wsgi_config.get('backend_port', '6379')
-        self.logger.debug('using backend port {0}'.format(backend_port))
+        backend_timeout_seconds = common.to_int(self.wsgi_config.get('backend_timeout_seconds'), 20)
+        backend_max_connections = common.to_int(self.wsgi_config.get('backend_max_connections'), 100)
 
         # Load configuration file.
         self.config = {}
@@ -89,8 +88,8 @@ class OpenStackRateLimitMiddleware(object):
             self.cadf_service_name = common.CADF_SERVICE_TYPE_PREFIX_MAP.get(self.service_type, None)
 
         # Use configured parameters or ensure defaults.
-        max_sleep_time_seconds = int(self.wsgi_config.get(common.Constants.max_sleep_time_seconds, 20))
-        log_sleep_time_seconds = int(self.wsgi_config.get(common.Constants.log_sleep_time_seconds, 10))
+        max_sleep_time_seconds = common.to_int(self.wsgi_config.get(common.Constants.max_sleep_time_seconds), 20)
+        log_sleep_time_seconds = common.to_int(self.wsgi_config.get(common.Constants.log_sleep_time_seconds), 10)
 
         # Setup ratelimit and blacklist response.
         self._setup_response()
@@ -126,7 +125,9 @@ class OpenStackRateLimitMiddleware(object):
                 rate_limit_response=self.ratelimit_response,
                 max_sleep_time_seconds=max_sleep_time_seconds,
                 log_sleep_time_seconds=log_sleep_time_seconds,
-                logger=self.logger
+                logger=self.logger,
+                timeout_seconds=backend_timeout_seconds,
+                max_connections=backend_max_connections,
             )
 
         # Test if the backend is ready.
@@ -346,6 +347,7 @@ class OpenStackRateLimitMiddleware(object):
                 )
                 return
 
+            # Returns a RateLimitResponse or BlacklistResponse or None, in which case the original response is returned.
             rate_limit_response = self._rate_limit(scope, action, target_type_uri)
             if rate_limit_response:
                 rate_limit_response.set_environ(environ)
@@ -421,18 +423,20 @@ class OpenStackRateLimitMiddleware(object):
         """
         Get the scope from the requests environ.
         The scope is configurable and may be the target|initiator project uid or the initiator host address.
+        Default to initiator project ID.
 
         :param environ: the requests environ
         :return: the scope
         """
-        scope = env_scope = None
+        scope = None
         if self.rate_limit_by == common.Constants.target_project_id:
             env_scope = environ.get('WATCHER.TARGET_PROJECT_ID', None)
         elif self.rate_limit_by == common.Constants.initiator_host_address:
             env_scope = environ.get('WATCHER.INITIATOR_HOST_ADDRESS', None)
         else:
             env_scope = environ.get('WATCHER.INITIATOR_PROJECT_ID', None)
-        # make sure the scope is not 'unknown'
+
+        # Ensure the scope is not 'unknown'.
         if not common.is_none_or_unknown(env_scope):
             scope = env_scope
         return scope
@@ -444,7 +448,7 @@ class OpenStackRateLimitMiddleware(object):
 
         :param environ: the request WSGI environment
         """
-        # get service type from environ
+        # Get service type from request environ.
         if common.is_none_or_unknown(self.service_type):
             svc_type = environ.get('WATCHER.SERVICE_TYPE')
             if not common.is_none_or_unknown(svc_type):

--- a/rate_limit/rate_limit.py
+++ b/rate_limit/rate_limit.py
@@ -60,9 +60,7 @@ class OpenStackRateLimitMiddleware(object):
         self.backend_host = wsgi_config.get('backend_host', '127.0.0.1')
         self.backend_port = common.to_int(self.wsgi_config.get('backend_port'), 6379)
         self.logger.debug(
-            "using backend '{0}' on '{1}:{2}'".format(
-                common.Constants.backend_redis, self.backend_host, self.backend_port
-            )
+            "using backend '{0}' on '{1}:{2}'".format('redis', self.backend_host, self.backend_port)
         )
         backend_timeout_seconds = common.to_int(self.wsgi_config.get('backend_timeout_seconds'), 20)
         backend_max_connections = common.to_int(self.wsgi_config.get('backend_max_connections'), 100)

--- a/rate_limit/tests/fake.py
+++ b/rate_limit/tests/fake.py
@@ -52,6 +52,7 @@ class FakeApp(object):
 class FakeKeystoneclient(object):
     def __init__(self):
         self.session = FakeSession()
+        self.services = []
 
 
 class FakeSession(object):

--- a/rate_limit/tests/test_limesratelimitprovider.py
+++ b/rate_limit/tests/test_limesratelimitprovider.py
@@ -31,11 +31,11 @@ class TestOpenStackRateLimitMiddlewareWithLimes(unittest.TestCase):
         limes_provider = provider.LimesRateLimitProvider(
             service_type=SERVICE_TYPE,
             refresh_interval_seconds=20,
+            keystone_client=fake.FakeKeystoneclient(),
+            limes_api_url='https://localhost:8887'
         )
-        limes_provider.keystone = fake.FakeKeystoneclient()
-        limes_provider.limes_base_url = 'https://localhost:8887'
 
-        # mock requests
+        # Mock requests to Limes.
         def _fake_get(path, params={}, headers={}):
             f = open(LIMESRATELIMITS)
             json_data = f.read()
@@ -55,14 +55,14 @@ class TestOpenStackRateLimitMiddlewareWithLimes(unittest.TestCase):
         rate_limit = self.watcher.ratelimit_provider.get_local_rate_limits(
             'abcdef1233456789', 'update', 'account/container/object'
         )
-        self.assertEqual(rate_limit, '10r/m', "the rate limit should be '10r/m'")
+        self.assertEqual(rate_limit, '10r/m', "the rate limit should be '10r/m' but got '{0}'".format(rate_limit))
 
         rate_limit = self.watcher.ratelimit_provider.get_local_rate_limits(
             '1233456789abcdef1233456789', 'delete', 'account/container'
         )
-        self.assertEqual(rate_limit, '2r/10m', "the rate limit should be '2r/10m'")
+        self.assertEqual(rate_limit, '2r/10m', "the rate limit should be '2r/10m' but got '{0}'".format(rate_limit))
 
         rate_limit = self.watcher.ratelimit_provider.get_local_rate_limits(
             'non_existent_project_id', 'delete', 'account/container'
         )
-        self.assertEqual(rate_limit, -1, "the rate limit should be '-1'")
+        self.assertEqual(rate_limit, -1, "the rate limit should be '-1' but got '{0}'".format(rate_limit))

--- a/rate_limit/tests/test_middleware.py
+++ b/rate_limit/tests/test_middleware.py
@@ -37,7 +37,7 @@ class TestOpenStackRateLimitMiddleware(unittest.TestCase):
             app=fake.FakeApp(),
             wsgi_config={
                 'config_file': SWIFTCONFIGPATH,
-                'max_sleep_time_seconds': 15,
+                'max_sleep_time_seconds': 20,
             }
         )
         self.is_setup = True
@@ -114,7 +114,7 @@ class TestOpenStackRateLimitMiddleware(unittest.TestCase):
             result = self.app._rate_limit(scope=scope, action=action, target_type_uri=target_type_uri)
             time.sleep(1)
             is_equal, msg = response_equal(expected[i], result)
-            self.assertTrue(is_equal, msg)
+            self.assertTrue(is_equal, "test #{0} failed: {1}".format(i, msg))
 
 
 def response_equal(expected, got):

--- a/rate_limit/tests/test_parse_config.py
+++ b/rate_limit/tests/test_parse_config.py
@@ -106,6 +106,18 @@ class TestParseConfig(unittest.TestCase):
         self.assertEqual(60, Units.parse('1m'))
         self.assertEqual(-1, Units.parse('mms'))
 
+    def test_load_lua_script(self):
+        content = common.load_lua_script('redis_sliding_window.lua')
+        self.assertIsNotNone(
+            content,
+            "the content of the lua script should not be None"
+        )
+        self.assertNotEqual(
+            content,
+            "",
+            "the content of the lua script should not be empty"
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ python-keystoneclient
 keystoneauth1>=3.1.0 # Apache-2.0
 redis~=3.1.0
 requests>=2.14.2 # Apache-2.0
-python-memcached~=1.59
 six
 WebOb>=1.7.1 # MIT
 PyYAML

--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,8 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['pbr'],
-    pbr=True)
+    pbr=True,
+    data_files=[
+        ('lua', ['rate_limit/lua/redis_sliding_window.lua'])
+    ]
+)


### PR DESCRIPTION
- Adds traffic shaping feature to handle burst requests: Process requests with delay if rate limit in current sliding window exceeded. Configurable via `max_sleep_time_seconds`. Closes #9.

- Avoid querying Limes for rate limits for every request. Instead cache rate limits in redis for a configurable duration `limes_refresh_interval_seconds`. 

- Attempt to fetch Limes URI for the given interface type after keystone authentication from the token's service catalog. Alternatively use the configured `limes_api_uri`. 

- The rate limit algorithm was re-written in LUA. Bonus points for performance when using SHA1 digest of algorithm in redis cache instead of sending the whole script and prerequisite for traffic shaping. 

- Completely drop memcache support. Only require `Redis >= 5.0.0`.

- Added notes on how to test the middleware and the specified rate limits using benchmarking tool [siege](https://github.com/JoeDog/siege)