### PR TITLE
Add wildcard configuration option for URI routes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ before_install:
 
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py27
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6
@@ -17,7 +15,7 @@ matrix:
       sudo: true
       env: TOXENV=py37
     - env: TOXENV=pep8
-      python: 2.7
+      python: 3.7
 
 install:
   pip install tox-travis

--- a/rate_limit/tests/fixtures/swift.yaml
+++ b/rate_limit/tests/fixtures/swift.yaml
@@ -48,8 +48,14 @@ rates:
       - action: create
         limit: 5r/30m
 
-    account/container/object:
+    account/container/*:
       - action: update
         limit: 2r/m
+      - action: read
+        limit: 2r/m
+
+    account/container/foo_object/something/else:
+      - action: update
+        limit: 4r/m
       - action: read
         limit: 2r/m

--- a/rate_limit/tests/test_parse_config.py
+++ b/rate_limit/tests/test_parse_config.py
@@ -39,27 +39,34 @@ class TestParseConfig(unittest.TestCase):
         self.assertEqual(
             conf.get('rates').get('default'),
             {
-                "account/container": [
+                'account/container': [
                     {
-                        "action": "update",
-                        "limit": "2r/m"
-                    },
-                    {
-                        "action": "create",
-                        "limit": "5r/30m"
+                        'action': 'update',
+                        'limit': '2r/m'
+                    }, {
+                        'action': 'create',
+                        'limit': '5r/30m'
                     }
                 ],
-                "account/container/object": [
+                'account/container/*': [
                     {
-                        "action": "update",
-                        "limit": "2r/m"
-                    },
+                        'action': 'update',
+                        'limit': '2r/m'
+                    }, {
+                        'action': 'read',
+                        'limit': '2r/m'
+                    }
+                ],
+                'account/container/foo_object/something/else': [
                     {
-                        "action": "read",
-                        "limit": "2r/m"
-                    },
+                        'action': 'update',
+                        'limit': '4r/m'
+                    }, {
+                        'action': 'read',
+                        'limit': '2r/m'
+                    }
                 ]
-            }
+            },
         )
 
     def test_parse_and_convert_to_per_seconds(self):

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,11 @@
 minversion = 2.0
 # avoid sdist
 skipsdist = True
-envlist = py27,py35,pep8
+envlist = py35,py36,py37,pep8
 
 [testenv]
 usedevelop = True
-install_command = {toxinidir}/tools/tox_install.sh {env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack/requirements/master/upper-constraints.txt} {opts} {packages}
+install_command = {toxinidir}/tools/tox_install.sh {env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/rocky-m3/upper-constraints.txt} {opts} {packages}
 setenv = VIRTUAL_ENV={envdir}
          BRANCH_NAME=master
          CLIENT_NAME=rate-limit


### PR DESCRIPTION
  The main idea behind URI route wildcard support is to avoid creating
  a ton of duplicate configurations for many services with long routes.