### PR TITLE
Use pyredis library instead of redis-py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-OpenStack Rate Limit Middleware
-===============================
+# OpenStack Rate Limit Middleware
 
 [![Build Status](https://travis-ci.org/sapcc/openstack-rate-limit-middleware.svg?branch=master)](https://travis-ci.org/sapcc/openstack-rate-limit-middleware) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-
 The OpenStack Rate Limit Middleware enforces rate limits and enables traffic shaping for OpenStack APIs per tuple of
-- *target type URI*
-- *action*
-- *scope* (project, host address)
+
+- _target type URI_
+- _action_
+- _scope_ (project, host address)
 
 It also supports enforcing global and scoped rate limits.
 More details can be found in the documentation.
@@ -17,9 +16,12 @@ More details can be found in the documentation.
 This middleware requires the classification for OpenStack requests.  
 The [openstack-watcher-middleware](https://github.com/sapcc/openstack-watcher-middleware) can be used to classify requests
 based on the [DMTF CADF specification](https://www.dmtf.org/standards/cadf).
-In terms of rate limiting, a request to an OpenStack service can be described by an *action*, *target type URI* and its *scope*.
+In terms of rate limiting, a request to an OpenStack service can be described by an _action_, _target type URI_ and its _scope_.
 
-Moreover, this middleware uses `Redis >= 5.0.0` as a backend to store rate limits.
+Moreover, this middleware only works with `Python 3` version and
+uses `Redis >= 5.0.0` as a backend to store rate limits.
+
+It's better to use `Redis` without persistent storage.
 
 ## Documentation
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,15 +1,16 @@
-Installation
-------------
+## Installation
 
 Install this middleware via
+
 ```
-pip install git+https://github.com/sapcc/openstack-rate-limit-middleware.git 
+pip install git+https://github.com/sapcc/openstack-rate-limit-middleware.git
 ```
 
-# Pipeline 
+# Pipeline
 
 This middleware relies on the request classification provided by the [openstack-watcher-middleware](https://github.com/sapcc/openstack-watcher-middleware)
 and must be added after it:
+
 ```
 pipeline = .. sapcc-watcher sapcc-rate-limit ..
 ```
@@ -17,6 +18,7 @@ pipeline = .. sapcc-watcher sapcc-rate-limit ..
 # WSGI configuration
 
 The following parameters are provided via the WSGI configuration:
+
 ```yaml
 # The service type according to CADF specification.
 service_type:                   <string>
@@ -27,7 +29,7 @@ config_file:                    <string>
 # If this middleware enforces rate limits in multiple replicas of an API,
 # the clock accuracy of the individual replicas can be configured as follows.
 # Especially in high-load scenarios, involving a sign. number of concurrent requests, choosing
-# nanosecond accuracy is advised - given support by OS and clock. 
+# nanosecond accuracy is advised - given support by OS and clock.
 clock_accuracy:                 <n><unit> (default: 1ns)
 
 # Per default rate limits are applied based on `initiator_project_id`.
@@ -36,7 +38,7 @@ rate_limit_by:                  <string>
 
 # The maximal time a request can be suspended in seconds.
 # Instead of immediately returning a rate limit response, a request can be suspended
-# until the specified maximum duration to fit the configured rate limit. 
+# until the specified maximum duration to fit the configured rate limit.
 # This feature can be disabled by setting the max sleep time to 0 seconds.
 max_sleep_time_seconds:         <int> (default: 20)
 
@@ -63,15 +65,16 @@ backend_port:                   <int> (default: 6379)
 backend_max_connections:        <int> (default: 100)
 
 # Timeout for obtaining a connection to the backend.
+# It should be >= 1 second.
 # Skips rate limit on timeout.
-backend_timeout_seconds:        <int> (default: 20)
+backend_timeout_seconds:        <int> (default: 2)
 
 ## Configure Limes as provider for rate limits.
 # See the limes guide for more details.
 limes_enabled:                  <bool> (default: false)
 
 # URI of the Limes API.
-# If not provided, the middleware attempts to autodiscover the URI of the Limes API using the  
+# If not provided, the middleware attempts to autodiscover the URI of the Limes API using the
 # service catalog of the Keystone token.
 limes_api_uri:                  <string>
 

--- a/rate_limit/utils.py
+++ b/rate_limit/utils.py
@@ -1,0 +1,53 @@
+# NOTE: This function was copied from
+# https://github.com/andymccurdy/redis-py/blob/master/redis/utils.py#L29
+def str_if_bytes(value):
+    return (
+        value.decode('utf-8', errors='replace')
+        if isinstance(value, bytes)
+        else value
+    )
+
+
+# NOTE: This function was copied from
+# https://github.com/andymccurdy/redis-py/blob/master/redis/client.py#L114
+def parse_info(response):
+    "Parse the result of Redis's INFO command into a Python dict"
+    info = {}
+    response = str_if_bytes(response)
+
+    def get_value(value):
+        if ',' not in value or '=' not in value:
+            try:
+                if '.' in value:
+                    return float(value)
+                else:
+                    return int(value)
+            except ValueError:
+                return value
+        else:
+            sub_dict = {}
+            for item in value.split(','):
+                k, v = item.rsplit('=', 1)
+                sub_dict[k] = get_value(v)
+            return sub_dict
+
+    for line in response.splitlines():
+        if line and not line.startswith('#'):
+            if line.find(':') != -1:
+                # Split, the info fields keys and values.
+                # Note that the value may contain ':'. but the 'host:'
+                # pseudo-command is the only case where the key contains ':'
+                key, value = line.split(':', 1)
+                if key == 'cmdstat_host':
+                    key, value = line.rsplit(':', 1)
+
+                if key == 'module':
+                    # Hardcode a list for key 'modules' since there could be
+                    # multiple lines that started with 'module'
+                    info.setdefault('modules', []).append(get_value(value))
+                else:
+                    info[key] = get_value(value)
+            else:
+                # if the line isn't splittable, append it to the "__raw__" key
+                info.setdefault('__raw__', []).append(line)
+    return info

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ datadog>=0.26.0
 eventlet>=0.20.0
 python-keystoneclient
 keystoneauth1>=3.1.0 # Apache-2.0
-redis
+python-redis
 requests>=2.14.2 # Apache-2.0
 six
 WebOb>=1.7.1 # MIT


### PR DESCRIPTION
    The decision to switch to the pyredis (works only with python3) library 
    was made due to issues with a non-configurable timeout during the eval 
    command when the Redis host is not available. 