### PR TITLE
python-redis needs crc16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ datadog>=0.26.0
 eventlet>=0.20.0
 python-keystoneclient
 keystoneauth1>=3.1.0 # Apache-2.0
+crc16
 python-redis
 requests>=2.14.2 # Apache-2.0
 six


### PR DESCRIPTION
see https://github.com/schlitzered/pyredis/blob/4f5049aae7ae2702f22ccfb661ca3f13869a3c31/setup.py#L29

but crc16 is no longer maintained, has issues on install https://github.com/gtrafimenkov/pycrc16/issues/5