### PR TITLE
Response headers should be text instead of integer

### DIFF
--- a/rate_limit/response.py
+++ b/rate_limit/response.py
@@ -77,10 +77,10 @@ class RateLimitExceededResponse(Response):
         :param remaining: the number of remaining requests within the current window
         :param retry_after: the remaining window before the rate limit resets in seconds
         """
-        self.headers[common.Constants.header_ratelimit_retry_after] = int(retry_after)
-        self.headers[common.Constants.header_ratelimit_reset] = int(retry_after)
+        self.headers[common.Constants.header_ratelimit_retry_after] = str(retry_after)
+        self.headers[common.Constants.header_ratelimit_reset] = str(retry_after)
         self.headers[common.Constants.header_ratelimit_limit] = str(ratelimit)
-        self.headers[common.Constants.header_ratelimit_remaining] = max(0, int(remaining))
+        self.headers[common.Constants.header_ratelimit_remaining] = str(max(0, int(remaining)))
 
     def set_environ(self, environ):
         """Set the environ of the request triggering this response."""


### PR DESCRIPTION
Only text are allowed in html headers, but some values are set as integer values. It breaks the rate limit responses and exceptions are thrown. As a result, the client receives 500 errors rather than the status code set for rate limit excesses. It somehow only happens when using json body in the response.