### PR TITLE
Handle empty ratelimit.yaml configuration

### DIFF
--- a/rate_limit/common.py
+++ b/rate_limit/common.py
@@ -160,7 +160,7 @@ def load_config(cfg_file):
     yaml_conf = {}
     try:
         with open(cfg_file, 'r') as f:
-            yaml_conf = yaml.safe_load(f)
+            yaml_conf = yaml.safe_load(f) or {}
     except IOError as e:
         raise errors.ConfigError("Failed to load configuration from file %s: %s" % (cfg_file, str(e)))
     finally:


### PR DESCRIPTION
Loading the config from a empty .yaml file returns a None object which will cause the middleware to crash during the initialization. Setting the value to a default dict, if the config is None, solves the problem.